### PR TITLE
Fix `invalidFrees` being a map instead of an array

### DIFF
--- a/js/hooks.js
+++ b/js/hooks.js
@@ -18,7 +18,7 @@
   }
 
   const liveAllocs = new Map();
-  const invalidFrees = new Map();
+  const invalidFrees = [];
 
   function getStack() {
     return Error()


### PR DESCRIPTION
Hey there, just stumbled into this one:

```
TypeError: invalidFrees.push is not a function
```